### PR TITLE
Add parameter for config file path

### DIFF
--- a/src/engine/config.go
+++ b/src/engine/config.go
@@ -1,16 +1,25 @@
 package engine
 
 import (
+	"flag"
 	"os"
 
 	"github.com/feed3r/21Updater/src/model"
 	"gopkg.in/yaml.v3"
 )
 
+// Parse a parameter to provide the config file path
+func getConfigFilePath() string {
+	confPath := flag.String("conf", "../conf/conf.yaml", "path to the configuration file")
+	flag.Parse()
+	return *confPath
+}
+
 func LoadConfig() (*model.Conf, error) {
 	var config model.Conf
 
-	data, err := os.ReadFile("../conf/conf.yaml")
+	configFilePath := getConfigFilePath()
+	data, err := os.ReadFile(configFilePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add a parameter -conf to specify the path for the configuration file.

Using the basic "flag" library also a --help parameter is enabled, so that future flags will automatically have documentation