### PR TITLE
Manage missing configuration file error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ src/.DS_Store
 .DS_Store
 test/__debug_bin*
 src/__debug_bin*
+main
+21Updater

--- a/src/engine/config.go
+++ b/src/engine/config.go
@@ -2,15 +2,18 @@ package engine
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/feed3r/21Updater/src/model"
 	"gopkg.in/yaml.v3"
 )
 
+var DEFAULT_CONFIG_PATH = "./conf/conf.yaml"
+
 // Parse a parameter to provide the config file path
 func getConfigFilePath() string {
-	confPath := flag.String("conf", "../conf/conf.yaml", "path to the configuration file")
+	confPath := flag.String("conf", DEFAULT_CONFIG_PATH, "path to the configuration file")
 	flag.Parse()
 	return *confPath
 }
@@ -21,6 +24,9 @@ func LoadConfig() (*model.Conf, error) {
 	configFilePath := getConfigFilePath()
 	data, err := os.ReadFile(configFilePath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			err = fmt.Errorf("Configuration file not found, please create a valid configuration file as " + DEFAULT_CONFIG_PATH + " or provide a valid path using the -conf flag")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
When configuration file is missing, return a specific error explaining what's happening